### PR TITLE
修复Redis服务器连接失败报错

### DIFF
--- a/src/System/View/Admin/Development/index.blade.php
+++ b/src/System/View/Admin/Development/index.blade.php
@@ -319,7 +319,18 @@
                   <div class="ml-2">Redis版本</div>
                 </dt>
                 <dd class="lg:mt-1 text-sm sm:mt-0 sm:col-span-2">
-                  {{ extension_loaded('redis') ? \Illuminate\Support\Facades\Redis::info()['redis_version'] : '暂未安装'}}
+                  @php
+                  try {
+                      if (extension_loaded('redis')) {
+                          $redisVersion = \Illuminate\Support\Facades\Redis::info()['redis_version'];
+                      } else {
+                          $redisVersion = '未安装扩展';
+                      }
+                  } catch (\Exception $e) {
+                      $redisVersion = '连接服务器失败';
+                  }
+                  echo $redisVersion;
+                  @endphp
                 </dd>
               </div>
               <div class="px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 flex items-center">


### PR DESCRIPTION
- 问题: 安装了Redis扩展，但未能连接上Redis服务器，运维监控界面打开报错500
- 方案: 兼容连接失败的情况，项目并非真正会用到Redis，此处仅为了获取Redis版本号而已。改了后对新手更友好。


采用 `@php` 原生标签而非写到后端代码侧，是因为看到模板中 MySQL 部分也写了原生 SQL，保持一致吧。